### PR TITLE
Updated base.css

### DIFF
--- a/mkdocs_theme/css/base.css
+++ b/mkdocs_theme/css/base.css
@@ -35,7 +35,7 @@ div.col-md-9 img {
     margin: 20px auto 30px auto;
 }
 
-h1, h2, h3 {
+h1, h2, h3, h4 {
     color: #444;
 }
 


### PR DESCRIPTION
For some reason, h4 was showing up in blue, which doesn't match the these. I added it here so that it shows up in #444, like other headings. I guess we could as well make it green, but it might be hard to read it.

@matyix 